### PR TITLE
feat(rules): add no-input-string-binding rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,22 @@
     "tsutils": "^2.12.1"
   },
   "devDependencies": {
+    "@angular/common": "^5.2.1",
+    "@angular/compiler": "^5.2.1",
+    "@angular/core": "^5.2.1",
+    "@angular/platform-browser": "^5.2.1",
+    "@angular/platform-browser-dynamic": "^5.2.1",
     "@types/node": "8.5.2",
+    "codelyzer": "4.1.0",
     "nyc": "11.4.1",
+    "rxjs": "^5.5.0",
     "tslint": "5.8.0",
-    "typescript": "2.6.2"
+    "typescript": "2.6.2",
+    "zone.js": "^0.8.20"
   },
   "peerDependencies": {
-    "tslint": "^5.8.0"
+    "tslint": "^5.8.0",
+    "codelyzer": "^4.1.0"
   },
   "engines": {
     "node": ">= 4"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { Rule as NoCrossDependenciesRule } from './noCrossDependenciesRule';
+export { Rule as NoInputStringBindingRule } from './noInputStringBindingRule';

--- a/src/noInputStringBindingRule.ts
+++ b/src/noInputStringBindingRule.ts
@@ -1,0 +1,66 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+import { NgWalker } from 'codelyzer/angular/ngWalker';
+import { BasicTemplateAstVisitor } from 'codelyzer/angular/templates/basicTemplateAstVisitor';
+import { BoundElementPropertyAst } from '@angular/compiler/src/template_parser/template_ast';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'no-input-string-binding',
+    type: 'functionality',
+    description: 'Do not use Input string binding.',
+    rationale: 'Do not use Input string binding it is considered as not the best practice.',
+    options: null,
+    optionsDescription: 'Not configurable.',
+    typescriptOnly: true
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(
+      new NgWalker(sourceFile,
+        this.getOptions(), {
+          templateVisitorCtrl: InputTemplateVisitor,
+        }));
+  }
+}
+
+const inputExpressionRe = new RegExp(/(\[)(.*)(\])/);
+const inputRe = new RegExp(/(\[)(.*)(\])\s*=\s*(?:'|")((?:'|")(.*)(?:'|"))(?:'|")/);
+
+class InputCheckTemplateVisitor extends BasicTemplateAstVisitor {
+  static Error = 'Use Input string without binding.';
+
+  visitElementProperty(prop: BoundElementPropertyAst, context: BasicTemplateAstVisitor): any {
+    if (prop.sourceSpan) {
+      const directive = (<any>prop.sourceSpan).toString();
+
+      const directiveMatch = directive.match(inputExpressionRe);
+      const expr = directiveMatch.input;
+
+      if (expr && inputRe.test(expr)) {
+        const span = prop.sourceSpan;
+
+        context.addFailure(
+          context.createFailure(span.start.offset, span.end.offset - span.start.offset, InputCheckTemplateVisitor.Error)
+        );
+      }
+    }
+    super.visitElementProperty(prop, context);
+  }
+}
+
+
+class InputTemplateVisitor extends BasicTemplateAstVisitor {
+  private visitors: (BasicTemplateAstVisitor)[] = [
+    new InputCheckTemplateVisitor(this.getSourceFile(), this.getOptions(), this.context, this.templateStart)
+  ];
+
+  visitElementProperty(prop: BoundElementPropertyAst, context: any): any {
+    this.visitors
+      .map(v => v.visitElementProperty(prop, this))
+      .filter(f => !!f)
+      .forEach(f => this.addFailure(f));
+    super.visitElementProperty(prop, context);
+  }
+
+}

--- a/tests/no-input-string-binding/test.ts.lint
+++ b/tests/no-input-string-binding/test.ts.lint
@@ -1,0 +1,4 @@
+<test1 data="Test"></test1>
+
+<test2 [data]="'Test'"></test2>
+        ~~~~~~~~~~~~~~  [Use Input string without binding.]

--- a/tests/no-input-string-binding/tslint.json
+++ b/tests/no-input-string-binding/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../rules"],
+  "rules": {
+    "no-input-string-binding": true
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,8 +10,7 @@
     "noLib": false,
     "outDir": "./rules",
     "typeRoots": [
-      "./node_modules/@types",
-      "./node_modules"
+      "./node_modules/@types"
     ],
     "types": [
       "node"


### PR DESCRIPTION
Added rule for avoiding use Input string binding.

**Bad**
```html
<component [title]="'Home page'"></component>
```

**Good**
```html
<component title="Home page"></component>
```