### PR TITLE
feat(rules): add ng-on-changes-interface rule

### DIFF
--- a/src/ngOnChangesInterfaceRule.ts
+++ b/src/ngOnChangesInterfaceRule.ts
@@ -1,0 +1,39 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'ng-on-changes-interface',
+    type: 'functionality',
+    description: 'Use appropriate type \'SimpleChanges\' for ngOnChanges.',
+    rationale: 'Ban to use type any for ngOnChanges.',
+    options: null,
+    optionsDescription: 'Not configurable.',
+    typescriptOnly: true
+  };
+
+  public static FAILURE_STRING = "Use appropriate type 'SimpleChanges' for ngOnChanges, not any.";
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithFunction(sourceFile, walk);
+  }
+}
+
+function walk(ctx: Lint.WalkContext<void>) {
+  return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+    if (node.kind === ts.SyntaxKind.MethodDeclaration) {
+      const method = node as ts.MethodDeclaration;
+      const methodName = (method.name as ts.StringLiteral).text;
+
+      if (methodName === 'ngOnChanges') {
+        for (const parameter of method.parameters) {
+          if (!parameter.type || parameter.type.kind === ts.SyntaxKind.AnyKeyword) {
+            return ctx.addFailure(method.getStart(), method.getWidth(), Rule.FAILURE_STRING);
+          }
+        }
+      }
+    }
+
+    return ts.forEachChild(node, cb);
+  });
+}

--- a/tests/ng-on-changes-interface/test.ts.lint
+++ b/tests/ng-on-changes-interface/test.ts.lint
@@ -1,0 +1,24 @@
+import { Component, OnChanges } from '@angular/core';
+
+@Component({
+  selector: 'test',
+  templateUrl: './test.component.html',
+  styleUrls: ['./test.component.scss']
+})
+export class CbFilterCategoryComponent implements OnChanges {
+  ngOnChanges(changes: any): void {
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Use appropriate type 'SimpleChanges' for ngOnChanges, not any.]
+  }
+}
+
+import { Component, OnChanges, SimpleChanges } from '@angular/core';
+
+@Component({
+  selector: 'test',
+  templateUrl: './test.component.html',
+  styleUrls: ['./test.component.scss']
+})
+export class CbFilterCategoryComponent implements OnChanges {
+  ngOnChanges(changes: SimpleChanges): void {
+  }
+}

--- a/tests/ng-on-changes-interface/tslint.json
+++ b/tests/ng-on-changes-interface/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../rules"],
+  "rules": {
+    "ng-on-changes-interface": true
+  }
+}


### PR DESCRIPTION
Added rule for avoiding use type `any` for ngOnChanges.

**Bad**
```typescript
ngOnChanges(changes: any) {
}
```

**Good**
```typescript
ngOnChanges(changes: SimpleChanges) {
}
```