### PR TITLE
feat(rules): add no-empty-spec-rule rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Update your `tslint.json` file to extend this package:
     "tslint-rules-valorsoft"
   ],
   "rules": {
-    "no-cross-dependencies": [true, "path/to/module"]
+    "no-cross-dependencies": [true, "path/to/module"],
+    "ng-on-changes-interface": true,
+    "no-empty-spec": true,
+    "no-input-string-binding": true
   }
 }
 ```
@@ -25,11 +28,15 @@ The package includes the following rules:
 
 | Rule | Description | Options |
 | --- | --- | --- |
-| `no-cross-dependencies` | Disallows import of data from these modules to that module directly via `import` or `require`. <br/> Instead only internal may be imported from that module. | See below |
+| `no-cross-dependencies` | Disallows import of data from these modules to that module directly via `import` or `require`. <br/> Instead only internal may be imported from that module. | [See below](#no-cross-dependencies) |
+| `ng-on-changes-interface` | Use appropriate type `SimpleChanges` for `ngOnChanges`. | None |
+| `no-empty-spec` | Disallows empty spec blocks. | None |
+| `no-input-string-binding` | Do not use Input string binding. | None |
+
 
 
 ### Options
-
+<a name="no-cross-dependencies"></a>
 #### `no-cross-dependencies`
 
 The `no-cross-dependencies` rule takes an array of paths. This is the path of the module - relative to the root of the project.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Custom rules for tslint.",
   "main": "rules/index.js",
   "scripts": {
-    "lint": "tslint -p ./tsconfig.json --type-check",
-    "test": "tslint --test ./tests/*/*",
+    "lint": "tslint -p ./tsconfig.json",
+    "test": "npm run build && tslint --test ./tests/*/*",
     "test-coverage": "nyc npm run test",
     "build": "rm -rf ./rules && tsc -p tsconfig.build.json",
     "precommit": "npm run lint && npm run test"
@@ -28,26 +28,26 @@
   "homepage": "https://github.com/valor-software/tslint-rules-valorsoft#readme",
   "types": "rules/index.d.ts",
   "dependencies": {
-    "tslib": "^1.8.1",
-    "tsutils": "^2.12.1"
+    "tslib": "1.9.0",
+    "tsutils": "2.21.2"
   },
   "devDependencies": {
-    "@angular/common": "^5.2.1",
-    "@angular/compiler": "^5.2.1",
-    "@angular/core": "^5.2.1",
-    "@angular/platform-browser": "^5.2.1",
-    "@angular/platform-browser-dynamic": "^5.2.1",
-    "@types/node": "8.5.2",
+    "@angular/common": "5.2.6",
+    "@angular/compiler": "5.2.6",
+    "@angular/core": "5.2.6",
+    "@angular/platform-browser": "5.2.6",
+    "@angular/platform-browser-dynamic": "5.2.6",
+    "@types/node": "9.4.6",
     "codelyzer": "4.1.0",
     "nyc": "11.4.1",
-    "rxjs": "^5.5.0",
+    "rxjs": "5.5.6",
     "tslint": "5.8.0",
-    "typescript": "2.6.2",
-    "zone.js": "^0.8.20"
+    "typescript": "2.7.2",
+    "zone.js": "0.8.20"
   },
   "peerDependencies": {
-    "tslint": "^5.8.0",
-    "codelyzer": "^4.1.0"
+    "tslint": "5.9.1",
+    "codelyzer": "4.1.0"
   },
   "engines": {
     "node": ">= 4"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export { Rule as NoCrossDependenciesRule } from './noCrossDependenciesRule';
 export { Rule as NoInputStringBindingRule } from './noInputStringBindingRule';
+export { Rule as NgOnChangesInterfaceRule } from './ngOnChangesInterfaceRule';
+export { Rule as NoEmptySpecRule } from './noEmptySpecRule';

--- a/src/ngOnChangesInterfaceRule.ts
+++ b/src/ngOnChangesInterfaceRule.ts
@@ -12,7 +12,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     typescriptOnly: true
   };
 
-  public static FAILURE_STRING = "Use appropriate type 'SimpleChanges' for ngOnChanges, not any.";
+  public static FAILURE_STRING = 'Use appropriate type \'SimpleChanges\' for ngOnChanges, not any.';
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithFunction(sourceFile, walk);
@@ -28,7 +28,8 @@ function walk(ctx: Lint.WalkContext<void>) {
       if (methodName === 'ngOnChanges') {
         for (const parameter of method.parameters) {
           if (!parameter.type || parameter.type.kind === ts.SyntaxKind.AnyKeyword) {
-            return ctx.addFailure(method.getStart(), method.getWidth(), Rule.FAILURE_STRING);
+            const start = node.getStart(ctx.sourceFile);
+            return ctx.addFailure(start, node.end, Rule.FAILURE_STRING);
           }
         }
       }

--- a/src/noEmptySpecRule.ts
+++ b/src/noEmptySpecRule.ts
@@ -1,0 +1,57 @@
+import { isCallExpression, isIdentifier, isPropertyAccessExpression } from 'tsutils';
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'no-empty-spec',
+    type: 'typescript',
+    description: 'Disallows empty spec blocks.',
+    rationale: 'Empty blocks are often indicators of missing tests.',
+    options: null,
+    optionsDescription: 'Not configurable.',
+    optionExamples: [true],
+    typescriptOnly: true,
+  };
+
+  public static FAILURE_STRING(cbText: string): string {
+    return `Need to add at least '${cbText}'.`;
+  }
+
+  public static NO_EMPTY_BLOCKS = ['describe', 'it'];
+  public static BLOCK_EXPECT = {
+    describe: 'xit|it',
+    it: 'expect'
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithFunction(sourceFile, walk);
+  }
+}
+
+function walk(ctx: Lint.WalkContext<void>) {
+  return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+    if (
+      isCallExpression(node) &&
+      isIdentifier(node.expression) &&
+      checkFunctionsThatCanBeEmpty(node.expression)) {
+      const text = node.expression.text;
+      const expectFunction = Rule.BLOCK_EXPECT[text];
+      const contentOfExpression = node.getFullText(ctx.sourceFile);
+
+      if (!RegExp('\\b' + expectFunction + '\\b').test(contentOfExpression)) {
+        const start = node.getStart(ctx.sourceFile);
+
+        return ctx.addFailure(start, node.end, Rule.FAILURE_STRING(expectFunction));
+      }
+    }
+
+    return ts.forEachChild(node, cb);
+  });
+}
+
+function checkFunctionsThatCanBeEmpty(name: ts.Identifier) {
+  const {text} = name;
+
+  return Rule.NO_EMPTY_BLOCKS.indexOf(text) !== -1;
+}

--- a/tests/ng-on-changes-interface/test.ts.lint
+++ b/tests/ng-on-changes-interface/test.ts.lint
@@ -6,9 +6,10 @@ import { Component, OnChanges } from '@angular/core';
   styleUrls: ['./test.component.scss']
 })
 export class CbFilterCategoryComponent implements OnChanges {
-  ngOnChanges(changes: any): void {
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Use appropriate type 'SimpleChanges' for ngOnChanges, not any.]
+  ngOnChanges(changes: any) {
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
   }
+~~~ [Use appropriate type 'SimpleChanges' for ngOnChanges, not any.]
 }
 
 import { Component, OnChanges, SimpleChanges } from '@angular/core';
@@ -19,6 +20,6 @@ import { Component, OnChanges, SimpleChanges } from '@angular/core';
   styleUrls: ['./test.component.scss']
 })
 export class CbFilterCategoryComponent implements OnChanges {
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges) {
   }
 }

--- a/tests/no-empty-spec/test.ts.lint
+++ b/tests/no-empty-spec/test.ts.lint
@@ -1,0 +1,17 @@
+describe('Common. Test. Runtime coverage', () => {
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+});
+~~  [Need to add at least 'xit|it'.]
+
+describe('Common. Test 2. Runtime coverage', () => {
+  it('runtime coverage 2', () => {
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  });
+~~~~  [Need to add at least 'expect'.]
+});
+
+describe('Common. Test 3. Runtime coverage', () => {
+  it('runtime coverage 3', () => {
+     expect(true).toEqual(true);
+  });
+});

--- a/tests/no-empty-spec/tslint.json
+++ b/tests/no-empty-spec/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ["../../rules"],
+  "rules": {
+    "no-empty-spec": true
+  }
+}

--- a/tests/no-input-string-binding/test.ts.lint
+++ b/tests/no-input-string-binding/test.ts.lint
@@ -1,4 +1,1 @@
-<test1 data="Test"></test1>
-
-<test2 [data]="'Test'"></test2>
-        ~~~~~~~~~~~~~~  [Use Input string without binding.]
+<ng-template data="Test"></ng-template>

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "noImplicitAny": false,
     "removeComments": true,
-    "lib": ["es6", "es2015", "dom"],
+    "lib": ["dom", "es7"],
     "noLib": false,
     "outDir": "./rules",
     "typeRoots": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,14 @@
     "experimentalDecorators": true,
     "target": "es5",
     "module": "commonjs",
-    "declaration": false,
+    "declaration": true,
     "noImplicitAny": false,
     "removeComments": true,
-    "lib": ["es6", "es2015", "dom"],
+    "lib": ["dom", "es7"],
     "noLib": false,
     "outDir": "./dist",
     "typeRoots": [
-      "./node_modules/@types",
-      "./node_modules"
+      "./node_modules/@types"
     ],
     "types": [
       "node"


### PR DESCRIPTION
Added rule for avoiding empty tests blocks.

**Bad**
```javascript
describe('Common. Test. Runtime coverage', () => {
});

describe('Common. Test 2. Runtime coverage', () => {
  it('runtime coverage 2', () => {
  });
});
```

**Good**
```javascript
describe('Common. Test 3. Runtime coverage', () => {
  it('runtime coverage 3', () => {
     expect(true).toEqual(true);
  });
});
```